### PR TITLE
Flag to clear the terminal before outputting text

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ revolutionary work on [Bionic Reading](https://bionic-reading.com)._
 For detailed usage run `fsrx -h`.
 
 ```
-fsrx 1.0.2
+fsrx 1.0.3
 Colby Thomas <thatvegandev@gmail.com>
 📚(f)low (s)tate (r)eading e(x)change
 flow state reading in the terminal
@@ -40,6 +40,7 @@ OPTIONS:
     -h, --help                   Print help information
     -s, --saccade <SACCADE>      saccade intensity [default: h] [possible values: l, m, h]
     -V, --version                Print version information
+    -w, --wipe			 Clear screen before printing output
 ```
 
 ### Examples

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,6 +25,10 @@ struct Cli {
     #[clap(short, long)]
     contrast: bool,
 
+    /// Clear screen before printing output
+    #[clap(short, long)]
+    wipe: bool,
+
     /// fixation intensity
     #[clap(short, long, arg_enum, default_value_t = Intensity::M)]
     fixation: Intensity,
@@ -50,6 +54,9 @@ fn main() -> io::Result<()> {
         Intensity::M => 2,
         Intensity::L => 3,
     };
+    if cli.wipe {
+        print!("\x1B[2J\x1B[1;1H");
+    }
     if cli.path.is_some() {
         if let Ok(lines) = read_lines(cli.path.as_ref().unwrap().as_str()) {
             lines.for_each(|line| {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Addition of a clear screen flag (-w  for wipe) which does a simple clear of the terminal before outputting stylized text.

<!-- Why are these changes necessary? -->

**Why**: I hve text flowing out of a program that I was piping to fsrx, that left a bunch of output above the text I was trying to read and I found this fatiguing. Clearing the screen makes for a nicer reading experience, but I couldn't find an elegant way to do this without writing the text to a file, clearing the screen, then using fsrx to read the file.

<!-- How were these changes implemented? -->

**How**: Addition of the wipe flag as a simple boolean, simple if statement within the main function, if set it then runs print!("\x1B[2J\x1B[1;1H"); which seems to be the lightest weight way to clear the terminal nicely.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] `Allow edits from maintainers` option checked
- [x] Branch name is prefixed with `[your_username]/` (ex. `thatvegandev/featureX`)
- [x] Documentation added
- [ ] Tests added N/A - I don't see any current test units
- [x] No failing actions
- [x] Merge ready
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
It's such a small change that I believe it should be fine.
      
<!-- feel free to add additional comments -->
First time ever working with Rust, so I'm a complete newbie... So please educate me if I've done anything stupid!